### PR TITLE
expect XCTestList not to be called and uniq testname

### DIFF
--- a/spec/fixtures/fake2.xctestrun
+++ b/spec/fixtures/fake2.xctestrun
@@ -118,7 +118,7 @@
 			<string>AtomicBoyUITests/testExample</string>
 			<string>AtomicBoyUITests/testExample2</string>
 			<string>AtomicBoyUITests/testExample3</string>
-			<string>AtomicBoyUITests/testExample4</string>
+			<string>AtomicBoyUITests/testExample44</string>
 		</array>
 		<key>SystemAttachmentLifetime</key>
 		<string>deleteOnSuccess</string>

--- a/spec/tests_from_xctestrun_spec.rb
+++ b/spec/tests_from_xctestrun_spec.rb
@@ -87,17 +87,8 @@ describe Fastlane::Actions::TestsFromXctestrunAction do
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with('path/to/fake2.xctestrun').and_return(true)
     allow(File).to receive(:read).with('path/to/fake2.xctestrun').and_return(File.read('./spec/fixtures/fake2.xctestrun'))
-    allow(XCTestList)
-      .to receive(:tests)
-      .with('path/to/Debug-iphonesimulator/AtomicBoyUITests-Runner.app/PlugIns/AtomicBoyUITests.xctest')
-      .and_return(
-        [
-          'AtomicBoyTests/AtomicBoyUITests/testExample',
-          'AtomicBoyTests/AtomicBoyUITests/testExample2',
-          'AtomicBoyTests/AtomicBoyUITests/testExample3',
-          'AtomicBoyTests/AtomicBoyUITests/testExample4'
-        ]
-      )
+    expect(XCTestList).not_to receive(:tests)
+
     fastfile = "lane :test do
       tests_from_xctestrun(
         xctestrun: 'path/to/fake2.xctestrun'
@@ -115,7 +106,7 @@ describe Fastlane::Actions::TestsFromXctestrunAction do
         'AtomicBoyUITests/AtomicBoyUITests/testExample',
         'AtomicBoyUITests/AtomicBoyUITests/testExample2',
         'AtomicBoyUITests/AtomicBoyUITests/testExample3',
-        'AtomicBoyUITests/AtomicBoyUITests/testExample4'
+        'AtomicBoyUITests/AtomicBoyUITests/testExample44'
       ]
     )
   end


### PR DESCRIPTION
I'd like to propose these two changes:
1. Expect for XCTestList not to be called.
2. Add a test that does not exist in the list of tests to be "only-tested" to confirm we are not getting it from a real test.